### PR TITLE
:sparkles: Day Streak, SolvedCount 추가, 카테고리 별 문제 수 API 추가

### DIFF
--- a/src/main/java/com/knu/coment/controller/CsQuestionController.java
+++ b/src/main/java/com/knu/coment/controller/CsQuestionController.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.Map;
+
 @Tag(name = "CSQuestion 컨트롤러", description = "CS Question API입니다.")
 @Controller
 @RequestMapping("/question")
@@ -63,6 +65,24 @@ public class CsQuestionController {
         return ApiResponseUtil.ok(
                 SuccessCode.SELECT_SUCCESS.getMessage(),
                 csQuestionInfoResponse
+        );
+    }
+    @Operation(summary = "카테고리별 질문 수 조회", description = "카테고리별 질문 수 조회 API입니다")
+    @GetMapping("/category")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리별 질문 수 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "카테고리별 질문 수 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<?> getCategoryCount(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        Map<String, Long> count = csQuestionService.getSolvedCountByCategory(githubId);
+
+        return ApiResponseUtil.ok(
+                SuccessCode.SELECT_SUCCESS.getMessage(),
+                count
         );
     }
 }

--- a/src/main/java/com/knu/coment/controller/FcmController.java
+++ b/src/main/java/com/knu/coment/controller/FcmController.java
@@ -49,8 +49,8 @@ public class FcmController {
             @ApiResponse(responseCode = "404", description = "FCM 토큰 삭제 실패"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ResponseEntity<?> deleteToken(@AuthenticationPrincipal UserDetails userDetails, @RequestParam String token) {
-        fcmService.deleteToken(token);
+    public ResponseEntity<?> deleteToken(@AuthenticationPrincipal UserDetails userDetails, @RequestBody FcmTokenDto dto) {
+        fcmService.deleteToken(dto.getFcmToken());
         return ApiResponseUtil.ok(
                 SuccessCode.DELETE_SUCCESS.getMessage()
         );

--- a/src/main/java/com/knu/coment/controller/ProjectCsQuestionController.java
+++ b/src/main/java/com/knu/coment/controller/ProjectCsQuestionController.java
@@ -2,6 +2,7 @@ package com.knu.coment.controller;
 
 import com.knu.coment.dto.gpt.*;
 import com.knu.coment.entity.Question;
+import com.knu.coment.global.CSCategory;
 import com.knu.coment.global.code.SuccessCode;
 import com.knu.coment.service.ProjectQuestionService;
 import com.knu.coment.util.ApiResponseUtil;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Tag(name = "PROJECT CSQuestion 컨트롤러", description = "PROJECT CS Question API입니다.")
@@ -62,9 +64,10 @@ public class ProjectCsQuestionController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ResponseEntity<?> getProjectCsQuestionList(@AuthenticationPrincipal UserDetails userDetails,
-                                                      @RequestParam Long projectId) {
+                                                      @RequestParam Long projectId,
+                                                      @RequestParam(required = false) CSCategory category) {
         String githubId = userDetails.getUsername();
-        List<CsQuestionListDto> csQuestionsList = projectQuestionService.getGroupedCsQuestions(githubId, projectId);
+        List<CsQuestionListDto> csQuestionsList = projectQuestionService.getGroupedCsQuestions(githubId, projectId, category);
 
         return ApiResponseUtil.ok(
                 SuccessCode.SELECT_SUCCESS.getMessage(),
@@ -88,6 +91,24 @@ public class ProjectCsQuestionController {
         return ApiResponseUtil.ok(
                 SuccessCode.SELECT_SUCCESS.getMessage(),
                 projectCsQuestionResponse
+        );
+    }
+    @Operation(summary = "카테고리별 질문 수 조회", description = "카테고리별 질문 수 조회 API입니다")
+    @GetMapping("/project/category")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리별 질문 수 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "카테고리별 질문 수 조회 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ResponseEntity<?> getProjectCategoryCount(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        Map<String, Long> count = projectQuestionService.getSolvedCountByCategory(githubId);
+
+        return ApiResponseUtil.ok(
+                SuccessCode.SELECT_SUCCESS.getMessage(),
+                count
         );
     }
 }

--- a/src/main/java/com/knu/coment/controller/UserStudyLogController.java
+++ b/src/main/java/com/knu/coment/controller/UserStudyLogController.java
@@ -1,0 +1,62 @@
+package com.knu.coment.controller;
+
+import com.knu.coment.dto.DailyStudyDto;
+import com.knu.coment.entity.User;
+import com.knu.coment.global.code.SuccessCode;
+import com.knu.coment.service.UserService;
+import com.knu.coment.service.UserStudyLogService;
+import com.knu.coment.util.ApiResponseUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Tag(name = "UserStudyLog 컨트롤러", description = "UserStudyLog API입니다.")
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/log")
+public class UserStudyLogController {
+    private final UserStudyLogService userStudyLogService;
+    private final UserService userService;
+
+    @Operation(summary = "최근 10일간 학습 기록 조회", description = "오늘을 포함하여 최근 10일 동안 날짜별로 문제를 푼 개수를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/history")
+    public ResponseEntity<?> getLast10DaysStudy(@AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        User user = userService.findByGithubId(githubId);
+        List<DailyStudyDto> result = userStudyLogService.getLast10DaysStudy(user.getId());
+        return ApiResponseUtil.ok(
+                SuccessCode.SELECT_SUCCESS.getMessage(),
+                result);
+    }
+
+    @Operation(summary = "연속 학습일 수 조회", description = "오늘을 기준으로 연속해서 문제를 푼 일 수를 계산해 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping()
+    public ResponseEntity<?> getStudyStreak(@AuthenticationPrincipal UserDetails userDetails) {
+        String githubId = userDetails.getUsername();
+        User user = userService.findByGithubId(githubId);
+        int streak = userStudyLogService.getStudyStreak(user.getId());
+        return ApiResponseUtil.ok(
+                SuccessCode.SELECT_SUCCESS.getMessage(),
+                streak);
+    }
+}

--- a/src/main/java/com/knu/coment/dto/DailyStudyDto.java
+++ b/src/main/java/com/knu/coment/dto/DailyStudyDto.java
@@ -1,0 +1,13 @@
+package com.knu.coment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class DailyStudyDto {
+    private LocalDate date;
+    private int solvedCount;
+}

--- a/src/main/java/com/knu/coment/dto/gpt/ProjectQuestionListDto.java
+++ b/src/main/java/com/knu/coment/dto/gpt/ProjectQuestionListDto.java
@@ -1,5 +1,6 @@
 package com.knu.coment.dto.gpt;
 
+import com.knu.coment.global.CSCategory;
 import com.knu.coment.global.QuestionStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,5 +12,6 @@ public class ProjectQuestionListDto {
     private String question;
     private String folderName;
     private QuestionStatus questionStatus;
+    private CSCategory csCategory;
     private String fileName;
 }

--- a/src/main/java/com/knu/coment/entity/UserStudyLog.java
+++ b/src/main/java/com/knu/coment/entity/UserStudyLog.java
@@ -1,0 +1,40 @@
+package com.knu.coment.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class UserStudyLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Column(nullable = false)
+    private LocalDate studyDate;
+
+    @Column(nullable = false)
+    private int solvedCount = 0;
+
+
+    @Builder
+    public UserStudyLog(Long userId, LocalDate studyDate, Integer solvedCount) {
+        this.userId = userId;
+        this.studyDate = studyDate;
+        this.solvedCount = (solvedCount == null) ? 0 : solvedCount;
+    }
+
+    public void updateSolvedCount(int solvedCount) {
+        if (solvedCount < 0) {
+            throw new IllegalArgumentException("푼 문제 수는 0 이상이어야 합니다.");
+        }
+        this.solvedCount = solvedCount;
+    }
+}

--- a/src/main/java/com/knu/coment/repository/QuestionRepository.java
+++ b/src/main/java/com/knu/coment/repository/QuestionRepository.java
@@ -54,5 +54,13 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             @Param("total") int totalRows
     );
 
+    @Query("""
+    SELECT q.csCategory, COUNT(q)
+    FROM Question q
+    WHERE q.userId = :userId
+      AND q.questionStatus = 'DONE'
+    GROUP BY q.csCategory
+""")
+    List<Object[]> countSolvedByCategory(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/knu/coment/repository/UserCSQuestionRepository.java
+++ b/src/main/java/com/knu/coment/repository/UserCSQuestionRepository.java
@@ -47,6 +47,14 @@ public interface UserCSQuestionRepository extends JpaRepository<UserCSQuestion, 
     @Query("DELETE FROM UserCSQuestion ucq WHERE ucq.userId = :userId AND ucq.questionStatus = 'TODO' AND ucq.date < :expiryDate")
     void deleteOldUnsolvedQuestions(@Param("userId") Long userId, @Param("expiryDate") LocalDate expiryDate);
 
+    @Query("SELECT q.csCategory, COUNT(uq) " +
+            "FROM UserCSQuestion uq " +
+            "JOIN Question q ON uq.questionId = q.id " +
+            "WHERE uq.userId = :userId AND uq.questionStatus = 'DONE' " +
+            "GROUP BY q.csCategory")
+    List<Object[]> countSolvedByCategory(@Param("userId") Long userId);
+
+
 
 }
 

--- a/src/main/java/com/knu/coment/repository/UserStudyLogRepository.java
+++ b/src/main/java/com/knu/coment/repository/UserStudyLogRepository.java
@@ -1,0 +1,16 @@
+package com.knu.coment.repository;
+
+import com.knu.coment.entity.UserStudyLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserStudyLogRepository extends JpaRepository<UserStudyLog, Long> {
+    Optional<UserStudyLog> findByUserIdAndStudyDate(Long userId, LocalDate studyDate);
+    List<UserStudyLog> findByUserIdAndStudyDateBetweenOrderByStudyDateDesc(Long userId, LocalDate startDate, LocalDate endDate);
+
+    List<UserStudyLog> findByUserIdAndStudyDateLessThanEqualOrderByStudyDateDesc(Long userId, LocalDate endDate);
+
+}

--- a/src/main/java/com/knu/coment/service/CSQuestionService.java
+++ b/src/main/java/com/knu/coment/service/CSQuestionService.java
@@ -103,5 +103,15 @@ public class CSQuestionService {
                 answerResponses
         );
     }
+    public Map<String, Long> getSolvedCountByCategory(String githubId) {
+        User user = userService.findByGithubId(githubId);
+        List<Object[]> rawResults = userCSQuestionRepository.countSolvedByCategory(user.getId());
+
+        return rawResults.stream()
+                .collect(Collectors.toMap(
+                        row -> row[0].toString(),
+                        row -> (Long) row[1]
+                ));
+    }
 
 }

--- a/src/main/java/com/knu/coment/service/UserStudyLogService.java
+++ b/src/main/java/com/knu/coment/service/UserStudyLogService.java
@@ -1,0 +1,83 @@
+package com.knu.coment.service;
+
+import com.knu.coment.dto.DailyStudyDto;
+import com.knu.coment.entity.UserStudyLog;
+import com.knu.coment.repository.UserStudyLogRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class UserStudyLogService {
+    private final UserStudyLogRepository userStudyLogRepository;
+
+    @Transactional
+    public void updateSolvedCount(Long userId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        Optional<UserStudyLog> optionalLog = userStudyLogRepository.findByUserIdAndStudyDate(userId, today);
+
+        if (optionalLog.isPresent()) {
+            UserStudyLog log = optionalLog.get();
+            log.updateSolvedCount(log.getSolvedCount() + 1);
+        } else {
+            UserStudyLog log = UserStudyLog.builder()
+                    .userId(userId)
+                    .studyDate(today)
+                    .solvedCount(1)
+                    .build();
+            userStudyLogRepository.save(log);
+        }
+    }
+
+    public List<DailyStudyDto> getLast10DaysStudy(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = today.minusDays(9);
+
+        List<UserStudyLog> logs = userStudyLogRepository
+                .findByUserIdAndStudyDateBetweenOrderByStudyDateDesc(userId, startDate, today);
+
+        Map<LocalDate, Integer> logMap = logs.stream()
+                .collect(Collectors.toMap(UserStudyLog::getStudyDate, UserStudyLog::getSolvedCount));
+
+        List<DailyStudyDto> result = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            LocalDate date = today.minusDays(i);
+            int solvedCount = logMap.getOrDefault(date, 0);
+            result.add(new DailyStudyDto(date, solvedCount));
+        }
+        Collections.reverse(result);
+        return result;
+    }
+
+    public int getStudyStreak(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        List<UserStudyLog> logs = userStudyLogRepository
+                .findByUserIdAndStudyDateLessThanEqualOrderByStudyDateDesc(userId, today);
+
+        int streak = 0;
+        LocalDate current = today;
+
+        for (UserStudyLog log : logs) {
+            if (log.getStudyDate().isEqual(current) && log.getSolvedCount() > 0) {
+                streak++;
+                current = current.minusDays(1);
+            } else if (log.getStudyDate().isBefore(current)) {
+                break; // 연속성 끊김
+            } else {
+                continue;
+            }
+        }
+
+        return streak;
+    }
+
+
+
+}

--- a/src/test/java/com/knu/coment/CSQuestionServiceTest.java
+++ b/src/test/java/com/knu/coment/CSQuestionServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,5 +166,29 @@ class CSQuestionServiceTest {
                 .isInstanceOf(com.knu.coment.exception.QuestionException.class)
                 .hasMessageContaining("질문을 찾을 수 없습니다");
     }
+    @Test
+    @DisplayName("getSolvedCountByCategory: 카테고리별 완료 문제 수 집계 성공")
+    void getSolvedCountByCategory_Success() {
+        // given
+        when(userService.findByGithubId("testUser")).thenReturn(user);
+
+        List<Object[]> mockResult = List.of(
+                new Object[]{"DATA_STRUCTURES_ALGORITHMS", 5L},
+                new Object[]{"OPERATING_SYSTEMS", 3L},
+                new Object[]{"NETWORKING", 2L}
+        );
+        when(userCSQuestionRepository.countSolvedByCategory(user.getId()))
+                .thenReturn(mockResult);
+
+        // when
+        Map<String, Long> result = csQuestionService.getSolvedCountByCategory("testUser");
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get("DATA_STRUCTURES_ALGORITHMS")).isEqualTo(5L);
+        assertThat(result.get("OPERATING_SYSTEMS")).isEqualTo(3L);
+        assertThat(result.get("NETWORKING")).isEqualTo(2L);
+    }
+
 
 }

--- a/src/test/java/com/knu/coment/UserStudyLogServiceTest.java
+++ b/src/test/java/com/knu/coment/UserStudyLogServiceTest.java
@@ -1,0 +1,101 @@
+package com.knu.coment;
+
+import com.knu.coment.dto.DailyStudyDto;
+import com.knu.coment.entity.UserStudyLog;
+import com.knu.coment.repository.UserStudyLogRepository;
+import com.knu.coment.service.UserStudyLogService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class UserStudyLogServiceTest {
+
+    private UserStudyLogRepository userStudyLogRepository;
+    private UserStudyLogService userStudyLogService;
+
+    @BeforeEach
+    void setUp() {
+        userStudyLogRepository = mock(UserStudyLogRepository.class);
+        userStudyLogService = new UserStudyLogService(userStudyLogRepository);
+    }
+
+    @Test
+    void updateSolvedCount_shouldCreateNewLogIfNotExists() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        when(userStudyLogRepository.findByUserIdAndStudyDate(userId, today))
+                .thenReturn(Optional.empty());
+
+        userStudyLogService.updateSolvedCount(userId);
+
+        ArgumentCaptor<UserStudyLog> captor = ArgumentCaptor.forClass(UserStudyLog.class);
+        verify(userStudyLogRepository).save(captor.capture());
+        UserStudyLog saved = captor.getValue();
+
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getStudyDate()).isEqualTo(today);
+        assertThat(saved.getSolvedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void updateSolvedCount_shouldIncrementSolvedCountIfExists() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        UserStudyLog existingLog = UserStudyLog.builder()
+                .userId(userId)
+                .studyDate(today)
+                .solvedCount(2)
+                .build();
+
+        when(userStudyLogRepository.findByUserIdAndStudyDate(userId, today))
+                .thenReturn(Optional.of(existingLog));
+
+        userStudyLogService.updateSolvedCount(userId);
+
+        assertThat(existingLog.getSolvedCount()).isEqualTo(3);
+        verify(userStudyLogRepository, never()).save(any());
+    }
+
+    @Test
+    void getLast10DaysStudy_shouldReturnAllDatesWithCounts() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        List<UserStudyLog> logs = List.of(
+                new UserStudyLog(userId, today.minusDays(1), 2),
+                new UserStudyLog(userId, today.minusDays(3), 1)
+        );
+        when(userStudyLogRepository.findByUserIdAndStudyDateBetweenOrderByStudyDateDesc(
+                eq(userId), any(), eq(today))
+        ).thenReturn(logs);
+
+        List<DailyStudyDto> result = userStudyLogService.getLast10DaysStudy(userId);
+
+        assertThat(result).hasSize(10);
+        assertThat(result.get(8).getSolvedCount()).isEqualTo(2); // today -1
+        assertThat(result.get(6).getSolvedCount()).isEqualTo(1); // today -3
+    }
+
+    @Test
+    void getStudyStreak_shouldCalculateConsecutiveDaysCorrectly() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.now();
+        List<UserStudyLog> logs = List.of(
+                new UserStudyLog(userId, today, 1),
+                new UserStudyLog(userId, today.minusDays(1), 1),
+                new UserStudyLog(userId, today.minusDays(2), 0),  // 끊김
+                new UserStudyLog(userId, today.minusDays(3), 1)
+        );
+
+        when(userStudyLogRepository.findByUserIdAndStudyDateLessThanEqualOrderByStudyDateDesc(userId, today))
+                .thenReturn(logs);
+
+        int streak = userStudyLogService.getStudyStreak(userId);
+        assertThat(streak).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
### ✅ 사용자 학습 통계 API 기능 추가

#### 📘 API 구현

* 🔹 **연속 학습일 수 조회 API**
* 🔹 **최근 10일간 문제 풀이 수 조회 API**
* 🔹 **CS 연습하기 – 카테고리별 문제 풀이 수 조회 API**
* 🔹 **프로젝트 질문 – 카테고리별 문제 풀이 수 조회 API**
* 🔹 **프로젝트 질문 리스트 – 카테고리 필터링 기능 추가**

#### 🧪 테스트

* ✅ **사용자 학습 통계 및 카테고리별 문제 수 JUnit 테스트 구현**
